### PR TITLE
DIP API Dokumentation: Link zu archive.org

### DIFF
--- a/index.json
+++ b/index.json
@@ -3,7 +3,7 @@
   "name": "DIP API",
   "description": "Über diese API ist ein lesender Zugriff auf die Entitäten von DIP (Vorgänge und Vorgangspositionen, Aktivitäten, Personen sowie Drucksachen und Plenarprotokolle) möglich.",
   "office": "Bundestag",
-  "documentationURL": "https://dip.bundestag.de/documents/informationsblatt_zur_dip_api_v01.pdf",
+  "documentationURL": "https://web.archive.org/web/20210808170331/https://dip.bundestag.de/documents/informationsblatt_zur_dip_api_v01.pdf",
   "githubURL": null
   },
   {


### PR DESCRIPTION
https://dip.bundestag.de/documents/informationsblatt_zur_dip_api_v01.pdf führt zu "Seite nicht gefunden" (mit Status 200 :disappointed:)

Einen aktuelleren Link konnte ich nicht finden (v02.pdf zum Beispiel gibt es nicht).

Das Web Archive hat allerdings eine Kopie: https://web.archive.org/web/20210808170331/https://dip.bundestag.de/documents/informationsblatt_zur_dip_api_v01.pdf.