### PR TITLE
fix(DIP API): Update URL auf eine, auf der der aktuelle Key sichtbar ist

### DIFF
--- a/index.json
+++ b/index.json
@@ -3,7 +3,7 @@
   "name": "DIP API",
   "description": "Über diese API ist ein lesender Zugriff auf die Entitäten von DIP (Vorgänge und Vorgangspositionen, Aktivitäten, Personen sowie Drucksachen und Plenarprotokolle) möglich.",
   "office": "Bundestag",
-  "documentationURL": "https://dip.bundestag.de/documents/informationsblatt_zur_dip_api.pdf",
+  "documentationURL": "https://dip.bundestag.de/über-dip/hilfe/api",
   "githubURL": null
   },
   {


### PR DESCRIPTION
Der aktuelle API-Key ist aus der Dokumentation selbst nicht ersichtlich. Dort steht, dass dieser persönlich angefragt werden muss. Dies ist aber nicht nötig, da unter der neuen URL immer ein aktueller API-Key steht, der mindestens ein halbes Jahr oder ein ganzes Jahr lang gültig ist.