### PR TITLE
index: fix documentation URL of Luftqualität API

### DIFF
--- a/index.json
+++ b/index.json
@@ -59,7 +59,7 @@
     "name": "Luftqualität",
     "office": "Umweltbundesamt",
     "description": "Schnittstellen der unterschiedlichen Visualisierungen der Luftdaten-Seite des Umweltbundesamtes.",
-    "documentationURL": "https://risikogebiete.api.bund.dev",
+    "documentationURL": "https://luftqualitaet.api.bund.dev",
     "githubURL": "https://github.com/bundesAPI/luftqualitaet-api"
   },
   {


### PR DESCRIPTION
The documentation URL of the Luftqualität API pointed to the documentation URL of the RKI API. This PR fixes that.