### PR TITLE
Auto-refreshing API list

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -1,0 +1,19 @@
+name: Refresh API list
+on:
+  schedule:
+    - cron: "0 4 * * *" # every day at 4 in the morning
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refresh list
+        run: node refresh.js
+      - name: Create Pull Request if needed
+        id: create-pull-request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: 'update api list'
+          title: '[bot] Update API list'
+          delete-branch: true

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           node-version: 16
           cache: 'npm'
+      - run: npm install
       - name: Refresh list
         run: node refresh.js
       - name: Create Pull Request if needed

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -8,6 +8,11 @@ jobs:
   refresh:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
       - name: Refresh list
         run: node refresh.js
       - name: Create Pull Request if needed

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# API Overview
+
+This repository hosts the list of documented APIs as JSON (in `index.json`). It can be accessed at https://api.bund.dev/.
+
+## Regenerating `index.json`
+
+The list is automatically updated each day, but can also be updated manually by running the `refresh` workflow.

--- a/index.json
+++ b/index.json
@@ -7,13 +7,6 @@
     "githubURL": "https://github.com/bundesAPI/abfallnavi-api"
   },
   {
-    "name": "Ausbildungssuche API",
-    "office": "Bundesagentur für Arbeit",
-    "description": "Eine der größten Ausbildungsdatenbanken Deutschlands durchsuchen.",
-    "documentationURL": "https://bundesapi.github.io/ausbildungssuche-api/",
-    "githubURL": "https://github.com/bundesAPI/ausbildungssuche-api"
-  },
-  {
     "name": "Autobahn App API",
     "office": "Autobahn GmbH",
     "description": "Was passiert auf Deutschlands Bundesstraßen? API für aktuelle Verwaltungsdaten zu Baustellen, Staus und Ladestationen. Außerdem Zugang zu Verkehrsüberwachungskameras und vielen weiteren Datensätzen.",

--- a/index.json
+++ b/index.json
@@ -7,6 +7,13 @@
     "githubURL": "https://github.com/bundesAPI/abfallnavi-api"
   },
   {
+    "name": "Ausbildungssuche API",
+    "office": "Bundesagentur für Arbeit",
+    "description": "Eine der größten Ausbildungsdatenbanken Deutschlands durchsuchen.",
+    "documentationURL": "https://bundesapi.github.io/ausbildungssuche-api/",
+    "githubURL": "https://github.com/bundesAPI/ausbildungssuche-api"
+  },
+  {
     "name": "Autobahn App API",
     "office": "Autobahn GmbH",
     "description": "Was passiert auf Deutschlands Bundesstraßen? API für aktuelle Verwaltungsdaten zu Baustellen, Staus und Ladestationen. Außerdem Zugang zu Verkehrsüberwachungskameras und vielen weiteren Datensätzen.",

--- a/index.json
+++ b/index.json
@@ -1,59 +1,10 @@
 [
   {
-    "name": "Tagesschau API",
-    "office": "ARD",
-    "description": "Dokumentation zur API der Tagesschau",
-    "documentationURL": "https://bundesapi.github.io/tagesschau-api/",
-    "githubURL": "https://github.com/bundesAPI/tagesschau-api"    
-  },
-  {
-    "name": "DIP Bundestag API",
-    "office": "Deutscher Bundestag",
-    "description": "Über diese API ist ein lesender Zugriff auf die Entitäten von DIP (Vorgänge und Vorgangspositionen, Aktivitäten, Personen sowie Drucksachen und Plenarprotokolle) möglich.",
-    "documentationURL": "https://dip.bundestag.de/%C3%BCber-dip/hilfe/api",
-    "githubURL": "https://github.com/bundesAPI/dip-bundestag-api"
-  },
-  {
-    "name": "Bundestag Lobbyregister API",
-    "office": "Deutscher Bundestag",
-    "description": "API des Deutschen Bundestags zum Lobbyregister für die Interessenvertretung gegenüber dem Deutschen Bundestag und der Bundesregierung.",
-    "documentationURL": null,
-    "githubURL": "https://github.com/bundesAPI/bundestag-lobbyregister-api"
-  },
-  {
-    "name": "Bundestag Live Informationen",
-    "office": "Bundestag",
-    "description": "Aktuelle Informationen aus dem deutschen Bundestag.",
-    "documentationURL": "https://bundestag.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/bundestag-api"
-  },
-  {
-    "name": "Bundesrat Live Informationen",
-    "office": "Bundesrat",
-    "description": "Aktuelle Informationen aus dem deutschen Bundesrat.",
-    "documentationURL": "https://bundesrat.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/bundesrat-api"
-  },
-  {
-    "name": "Bundeshaushalt API",
-    "office": "Bundesministerium der Finanzen",
-    "description": "API Beschreibung von Bundeshaushalt Digital.",
-    "documentationURL": null,
-    "githubURL": "https://github.com/bundesAPI/bundeshaushalt-api"
-  }, 
-  {
-    "name": "Jobsuche API",
-    "office": "Bundesagentur für Arbeit",
-    "description": "Die größte Stellendatenbank Deutschlands durchsuchen, Details zu Stellenanzeigen und Informationen über Arbeitgeber abrufen.",
-    "documentationURL": "https://jobsuche.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/jobsuche-api"
-  },
-  {
-    "name": "Weiterbildungssuche API",
-    "office": "Bundesagentur für Arbeit",
-    "description": "Eine der größten Weiterbildungsdatenbanken Deutschlands durchsuchen.",
-    "documentationURL": "https://bundesapi.github.io/weiterbildungssuche-api/",
-    "githubURL": "https://github.com/bundesAPI/weiterbildungssuche-api"
+    "name": "Abfallnavi API",
+    "office": "regio iT",
+    "description": "Zugriff auf die Termine der Müllabfuhr unterschiedlicher Kommunen.",
+    "documentationURL": "https://bundesapi.github.io/abfallnavi-api/",
+    "githubURL": "https://github.com/bundesAPI/abfallnavi-api"
   },
   {
     "name": "Ausbildungssuche API",
@@ -63,11 +14,46 @@
     "githubURL": "https://github.com/bundesAPI/ausbildungssuche-api"
   },
   {
-    "name": "Studiensuche API",
+    "name": "Autobahn App API",
+    "office": "Autobahn GmbH",
+    "description": "Was passiert auf Deutschlands Bundesstraßen? API für aktuelle Verwaltungsdaten zu Baustellen, Staus und Ladestationen. Außerdem Zugang zu Verkehrsüberwachungskameras und vielen weiteren Datensätzen.",
+    "documentationURL": "https://autobahn.api.bund.dev/",
+    "githubURL": "https://github.com/bundesAPI/autobahn-api"
+  },
+  {
+    "name": "Berufssprachkurssuche API",
     "office": "Bundesagentur für Arbeit",
-    "description": "Eine der größten Datenbanken für Studienangebote in Deutschland durchsuchen.",
-    "documentationURL": "https://bundesapi.github.io/studiensuche-api/",
-    "githubURL": "https://github.com/bundesAPI/studiensuche-api"
+    "description": "Eine der größten Berufssprachkursdatenbanken Deutschlands durchsuchen.",
+    "documentationURL": "https://bundesapi.github.io/berufssprachkurssuche-api/",
+    "githubURL": "https://github.com/bundesAPI/berufssprachkurssuche-api"
+  },
+  {
+    "name": "Bundeshaushalt API",
+    "office": "Bundesministerium der Finanzen",
+    "description": "API Beschreibung von Bundeshaushalt Digital",
+    "documentationURL": null,
+    "githubURL": "https://github.com/bundesAPI/bundeshaushalt-api"
+  },
+  {
+    "name": "Bundesrat: Live Informationen",
+    "office": "Bundesrat",
+    "description": "Aktuelle Informationen aus dem deutschen Bundesrat.",
+    "documentationURL": "https://bundesrat.api.bund.dev",
+    "githubURL": "https://github.com/bundesAPI/bundesrat-api"
+  },
+  {
+    "name": "Bundestag: Live Informationen",
+    "office": "Bundestag",
+    "description": "Aktuelle Informationen aus dem deutschen Bundestag.",
+    "documentationURL": "https://bundestag.api.bund.dev",
+    "githubURL": "https://github.com/bundesAPI/bundestag-api"
+  },
+  {
+    "name": "Bundestag: Lobbyregister API",
+    "office": "Deutscher Bundestag",
+    "description": "API des Deutschen Bundestags zum Lobbyregister für die Interessenvertretung gegenüber dem Deutschen Bundestag und der Bundesregierung.",
+    "documentationURL": null,
+    "githubURL": "https://github.com/bundesAPI/bundestag-lobbyregister-api"
   },
   {
     "name": "Coachingangebote API",
@@ -77,12 +63,40 @@
     "githubURL": "https://github.com/bundesAPI/coachingangebote-api"
   },
   {
-    "name": "Berufssprachkurssuche API",
-    "office": "Bundesagentur für Arbeit",
-    "description": "Eine der größten Berufssprachkursdatenbanken Deutschlands durchsuchen.",
-    "documentationURL": "https://bundesapi.github.io/berufssprachkurssuche-api/",
-    "githubURL": "https://github.com/bundesAPI/berufssprachkurssuche-api"
-  },    
+    "name": "Dashboard Deutschland API",
+    "office": "Statistisches Bundesamt",
+    "description": "Statistische Daten des DESTATIS Deutschland Deutschland per API abrufen.",
+    "documentationURL": "https://bundesapi.github.io/dashboard-deutschland-api/",
+    "githubURL": "https://github.com/bundesAPI/dashboard-deutschland-api"
+  },
+  {
+    "name": "Destatis-API",
+    "office": "Statistisches Bundesamt",
+    "description": "Statistische Daten des DESTATIS via restful API abrufen.",
+    "documentationURL": "https://destatis.api.bund.dev/",
+    "githubURL": "https://github.com/bundesAPI/destatis-api"
+  },
+  {
+    "name": "DIP Bundestag API",
+    "office": "Deutscher Bundestag",
+    "description": "Über diese API ist ein lesender Zugriff auf die Entitäten von DIP (Vorgänge und Vorgangspositionen, Aktivitäten, Personen sowie Drucksachen und Plenarprotokolle) möglich.",
+    "documentationURL": "https://dip.bundestag.de/%C3%BCber-dip/hilfe/api",
+    "githubURL": "https://github.com/bundesAPI/dip-bundestag-api"
+  },
+  {
+    "name": "DWD App API",
+    "office": "Deutscher Wetterdienst",
+    "description": "Aktuelle Wetterdaten von allen Deutschen Wetterstationen",
+    "documentationURL": "https://dwd.api.bund.dev/",
+    "githubURL": "https://github.com/bundesAPI/dwd-api"
+  },
+  {
+    "name": "Eco-Visio API",
+    "office": "Eco-Counter",
+    "description": "API zum Eco-Visio-Dashboard von Eco-Counter",
+    "documentationURL": null,
+    "githubURL": "https://github.com/bundesAPI/eco-visio-api"
+  },
   {
     "name": "Entgeltatlas API",
     "office": "Bundesagentur für Arbeit",
@@ -91,19 +105,26 @@
     "githubURL": "https://github.com/bundesAPI/entgeltatlas-api"
   },
   {
-    "name": "DESTATIS API",
-    "office": "Statistisches Bundesamt",
-    "description": "Statistische Daten des DESTATIS via restful API abrufen.",
-    "documentationURL": "https://destatis.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/destatis-api"
+    "name": "Feiertage API",
+    "office": "Wikipedia",
+    "description": "Zugriff auf den Feiertage Webservice https://feiertage-api.de/.",
+    "documentationURL": null,
+    "githubURL": "https://github.com/bundesAPI/feiertage-api"
   },
   {
-    "name": "Dashboard Deutschland API",
-    "office": "Statistisches Bundesamt",
-    "description": "Statistische Daten des DESTATIS Deutschland Deutschland per API abrufen.",
-    "documentationURL": "https://bundesapi.github.io/dashboard-deutschland-api/",
-    "githubURL": "https://github.com/bundesAPI/dashboard-deutschland-api"
-  },    
+    "name": "Hilfsmittel-API",
+    "office": "Spitzenverband GKV",
+    "description": "API des GKV-Spitzenverbands zu allen Hilfsmitteln, die unter die Leistungspflicht der Kassen fallen.",
+    "documentationURL": null,
+    "githubURL": "https://github.com/bundesAPI/hilfsmittel-api"
+  },
+  {
+    "name": "Hochwasserzentralen API",
+    "office": "LfU & LUBW",
+    "description": "Länderübergreifendes Hochwasserportal (LHP) ",
+    "documentationURL": "https://bundesapi.github.io/hochwasserzentralen-api/",
+    "githubURL": "https://github.com/bundesAPI/hochwasserzentralen-api"
+  },
   {
     "name": "Interpol Notices API",
     "office": "Interpol",
@@ -112,157 +133,31 @@
     "githubURL": "https://github.com/bundesAPI/interpol-api"
   },
   {
-    "name": "Polizei Brandenburg API",
-    "office": "Polizei Brandenburg",
-    "description": "Polizei Brandenburg Nachrichten, Hochwasser-, Verkehrs- und Waldbrandwarnungen.",
-    "documentationURL": "https://polizei.brandenburg.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/polizei-brandenburg-api"
-  },
-  {
-    "name": "Autobahn App API",
-    "office": "Autobahn GmbH",
-    "description": "Was passiert auf Deutschlands Bundesstraßen? API für aktuelle Verwaltungsdaten zu Baustellen, Staus und Ladestationen. Außerdem Zugang zu Verkehrsüberwachungskameras und vielen weiteren Datensätzen.",
-    "documentationURL": "https://autobahn.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/autobahn-api"
-  },
-  {
-    "name": "Eco-Visio API",
-    "office": "Eco-Counter",
-    "description": "API zu Eco-Visio von Eco-Counter.",
-    "documentationURL": null,
-    "githubURL": "https://github.com/bundesAPI/eco-visio-api"
+    "name": "Jobsuche API",
+    "office": "Bundesagentur für Arbeit",
+    "description": "Die größte Stellendatenbank Deutschlands durchsuchen, Details zu Stellenanzeigen und Informationen über Arbeitgeber abrufen.",
+    "documentationURL": "https://jobsuche.api.bund.dev/",
+    "githubURL": "https://github.com/bundesAPI/jobsuche-api"
   },
   {
     "name": "Ladesäulenregister",
     "office": "Bundesnetzagentur",
     "description": "API des Ladesäulenregisters der Bundesnetzagentur",
-    "documentationURL": "https://ladestationen.api.bund.dev",
+    "documentationURL": "https://ladestationen.api.bund.dev/",
     "githubURL": "https://github.com/bundesAPI/ladestationen-api"
-  },  
-  {
-    "name": "NINA API",
-    "office": "Bundesamt für Bevölkerungsschutz",
-    "description": "Erhalten Sie wichtige Warnmeldungen des Bevölkerungsschutzes für Gefahrenlagen wie zum Beispiel Gefahrstoffausbreitung oder Unwetter per Programmierschnittstelle.",
-    "documentationURL": "https://nina.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/nina-api"
-  },  
-  {
-    "name": "ODL-Info API",
-    "office": "Bundesamt für Strahlenschutz",
-    "description": "Daten zur radioaktiven Belastung in Deutschland.",
-    "documentationURL": "https://strahlenschutz.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/strahlenschutz-api"
-  },  
-  {
-    "name": "Reisewarnungen OpenData Schnittstelle",
-    "office": "Auswärtigen Amtes",
-    "description": "Zugriff auf Reisewarnungen des Auswärtigen Amtes im Rahmen der OpenData Initiative.",
-    "documentationURL": "https://travelwarning.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/travelwarning-api"
-  },  
-  {
-    "name": "Corona Risikogebiete API",
-    "office": "Robert Koch Institut",
-    "description": "Aktuelle Corona Risikogebietsinformationen als API.",
-    "documentationURL": "https://risikogebiete.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/risikogebiete-api"
   },
   {
-    "name": "Hochwasserzentralen API",
-    "office": "LfU & LUBW",
-    "description": "Länderübergreifendes Hochwasserportal (LHP) ",
-    "documentationURL": "https://bundesapi.github.io/hochwasserzentralen-api/",
-    "githubURL": "https://github.com/bundesAPI/hochwasserzentralen-api"
-  }, 
-  {
-    "name": "DWD App API",
-    "office": "Deutscher Wetterdienst",
-    "description": "Aktuelle Wetterdaten von allen Deutschen Wetterstationen",
-    "documentationURL": "https://dwd.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/dwd-api"
-  },    
+    "name": "Lebensmittelwarnungen API",
+    "office": "Bundesamt für Verbraucherschutz und Lebensmittelsicherheit",
+    "description": "Liste aller Lebensmittel und Produktwarnungen.",
+    "documentationURL": "https://lebensmittelwarnung.api.bund.dev/",
+    "githubURL": "https://github.com/bundesAPI/lebensmittelwarnung-api"
+  },
   {
     "name": "Luftqualität",
     "office": "Umweltbundesamt",
     "description": "Schnittstellen der unterschiedlichen Visualisierungen der Luftdaten-Seite des Umweltbundesamtes.",
     "documentationURL": "https://luftqualitaet.api.bund.dev",
     "githubURL": "https://github.com/bundesAPI/luftqualitaet-api"
-  },  
-  {
-    "name": "Meeresumweltdatenbank (MUDAB) 1.0.0",
-    "office": "Umweltbundesamt",
-    "description": "Meeres-Monitoringdaten von Küstenbundesländern und Forschungseinrichtungen.",
-    "documentationURL": "https://mudab.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/mudab-api"
-  },
-  {
-    "name": "Abfallnavi API",
-    "office": "regio iT",
-    "description": "Zugriff auf die Termine der Müllabfuhr unterschiedlicher Kommunen.",
-    "documentationURL": "https://bundesapi.github.io/abfallnavi-api/",
-    "githubURL": "https://github.com/bundesAPI/abfallnavi-api"
-  },    
-  {
-    "name": "Feiertage API",
-    "office": "Wikipedia",
-    "description": "Zugriff auf den Feiertage Webservice https://feiertage-api.de/ .",
-    "documentationURL": null,
-    "githubURL": "https://github.com/bundesAPI/feiertage-api"
-  },     
-  {
-    "name": "Lebensmittelwarnungen API",
-    "office": "Bundesamt für Verbraucherschutz und Lebensmittelsicherheit",
-    "description": "Liste aller Lebensmittel und Produktwarnungen.",
-    "documentationURL": "https://lebensmittelwarnung.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/lebensmittelwarnung-api"
-  },
-  {
-    "name": "Pflanzenschutzmittelzulassungen API",
-    "office": "Bundesamt für Verbraucherschutz und Lebensmittelsicherheit",
-    "description": "Informationen über die in Deutschland zugelassenen Pflanzenschutzmittel.",
-    "documentationURL": null,
-    "githubURL": "https://github.com/bundesAPI/pflanzenschutzmittelzulassung-api"
-  },
-  {
-    "name": "Einfuhrzoll API",
-    "office": "Bundeszollverwaltung",
-    "description": "API zum Abfragen von Importzöllen und Wechselkursen.",
-    "documentationURL": "https://zoll.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/zoll-api"
-  },  
-  {
-    "name": "Handelsregister",
-    "office": "Landesjustizverwaltung Nordrhein-Westfalen im Auftrag aller Länder der Bundesrepublik Deutschland",
-    "description": "API zum Abruf von allgemeinen Unternehmensinformationen über jedes Unternehmen im Handelsregister.",
-    "documentationURL": null,
-    "githubURL": "https://github.com/bundesAPI/handelsregister"
-  },
-  {
-    "name": "SMARD API",
-    "office": "Bundesnetzagentur",
-    "description": "Zugriff auf Strommarktdaten der Bundesnetzagentur.",
-    "documentationURL": "https://smard.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/smard-api"
-  },
-  {
-    "name": "FIT-Connect",
-    "office": "FITKO",
-    "description": "Die Schnittstelle ermöglicht Ihnen, Anträge und Berichte aus Ihren eigenen Systemen in die unterschiedlichen Systeme der Verwaltung zu übermitteln.",
-    "documentationURL": "https://fit-connect.fitko.de/",
-    "githubURL": "https://git.fitko.de/fit-connect"
-  },
-  {
-    "name": "Rechtsinformationsportal",
-    "office": "Bundesministerium der Justiz und für Verbraucherschutz",
-    "description": "Die Schnittstelle ermöglicht Dritten Zugriff auf die Daten von Gesetze-im-Internet.de",
-    "documentationURL": "https://api.rechtsinformationsportal.de/",
-    "githubURL": "https://github.com/tech4germany/rechtsinfo_api"
-  },
-  {
-    "name": "VAG API",
-    "office": "VAG",
-    "description": "Web-API für Echtzeitinformationen der VAG",
-    "documentationURL": "https://bundesapi.github.io/vag-api/",
-    "githubURL": "https://github.com/bundesAPI/vag-api"
   }
 ]

--- a/index.json
+++ b/index.json
@@ -7,9 +7,6 @@
     "githubURL": "https://github.com/bundesAPI/abfallnavi-api"
   },
   {
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
     "name": "Ausbildungssuche API",
     "office": "Bundesagentur für Arbeit",
     "description": "Eine der größten Ausbildungsdatenbanken Deutschlands durchsuchen.",
@@ -17,19 +14,11 @@
     "githubURL": "https://github.com/bundesAPI/ausbildungssuche-api"
   },
   {
->>>>>>> 7d9c7d256091c286d7b9b45996a93a0c38dc6ed2
     "name": "Autobahn App API",
     "office": "Autobahn GmbH",
     "description": "Was passiert auf Deutschlands Bundesstraßen? API für aktuelle Verwaltungsdaten zu Baustellen, Staus und Ladestationen. Außerdem Zugang zu Verkehrsüberwachungskameras und vielen weiteren Datensätzen.",
     "documentationURL": "https://autobahn.api.bund.dev/",
     "githubURL": "https://github.com/bundesAPI/autobahn-api"
-=======
-    "name": "Bundestag Live Informationen",
-    "office": "Deutscher Bundestag",
-    "description": "Aktuelle Informationen aus dem deutschen Bundestag.",
-    "documentationURL": "https://bundestag.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/bundestag-api"
->>>>>>> 52387e1bd6c47b2000edc2c73806d18411ec085d
   },
   {
     "name": "Berufssprachkurssuche API",
@@ -44,23 +33,6 @@
     "description": "API Beschreibung von Bundeshaushalt Digital",
     "documentationURL": null,
     "githubURL": "https://github.com/bundesAPI/bundeshaushalt-api"
-<<<<<<< HEAD
-=======
-  }, 
-  {
-    "name": "Rechtsinformationsportal",
-    "office": "Bundesministerium der Justiz und für Verbraucherschutz",
-    "description": "Die Schnittstelle ermöglicht Dritten Zugriff auf die Daten von Gesetze-im-Internet.de",
-    "documentationURL": "https://api.rechtsinformationsportal.de/",
-    "githubURL": "https://github.com/tech4germany/rechtsinfo_api"
-  },
-  {
-    "name": "Jobsuche API",
-    "office": "Bundesagentur für Arbeit",
-    "description": "Die größte Stellendatenbank Deutschlands durchsuchen, Details zu Stellenanzeigen und Informationen über Arbeitgeber abrufen.",
-    "documentationURL": "https://jobsuche.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/jobsuche-api"
->>>>>>> 52387e1bd6c47b2000edc2c73806d18411ec085d
   },
   {
     "name": "Bundesrat: Live Informationen",
@@ -91,44 +63,6 @@
     "githubURL": "https://github.com/bundesAPI/coachingangebote-api"
   },
   {
-<<<<<<< HEAD
-=======
-    "name": "Berufssprachkurssuche API",
-    "office": "Bundesagentur für Arbeit",
-    "description": "Eine der größten Berufssprachkursdatenbanken Deutschlands durchsuchen.",
-    "documentationURL": "https://bundesapi.github.io/berufssprachkurssuche-api/",
-    "githubURL": "https://github.com/bundesAPI/berufssprachkurssuche-api"
-  },    
-  {
-    "name": "Entgeltatlas API",
-    "office": "Bundesagentur für Arbeit",
-    "description": "Eine Datenbank zu Entgelten für Berufstätigkeiten in Deutschland durchsuchen.",
-    "documentationURL": "https://bundesapi.github.io/entgeltatlas-api/",
-    "githubURL": "https://github.com/bundesAPI/entgeltatlas-api"
-  },
-    {
-    "name": "Ladesäulenregister",
-    "office": "Bundesnetzagentur",
-    "description": "API des Ladesäulenregisters der Bundesnetzagentur",
-    "documentationURL": "https://ladestationen.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/ladestationen-api"
-  },  
-  {
-    "name": "SMARD API",
-    "office": "Bundesnetzagentur",
-    "description": "Zugriff auf Strommarktdaten der Bundesnetzagentur.",
-    "documentationURL": "https://smard.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/smard-api"
-  },
-  {
-    "name": "DESTATIS API",
-    "office": "Statistisches Bundesamt",
-    "description": "Statistische Daten des DESTATIS via restful API abrufen.",
-    "documentationURL": "https://destatis.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/destatis-api"
-  },
-  {
->>>>>>> 52387e1bd6c47b2000edc2c73806d18411ec085d
     "name": "Dashboard Deutschland API",
     "office": "Statistisches Bundesamt",
     "description": "Statistische Daten des DESTATIS Deutschland Deutschland per API abrufen.",
@@ -136,7 +70,6 @@
     "githubURL": "https://github.com/bundesAPI/dashboard-deutschland-api"
   },
   {
-<<<<<<< HEAD
     "name": "Destatis-API",
     "office": "Statistisches Bundesamt",
     "description": "Statistische Daten des DESTATIS via restful API abrufen.",
@@ -177,48 +110,6 @@
     "description": "Zugriff auf den Feiertage Webservice https://feiertage-api.de/.",
     "documentationURL": null,
     "githubURL": "https://github.com/bundesAPI/feiertage-api"
-=======
-    "name": "NINA API",
-    "office": "Bundesamt für Bevölkerungsschutz",
-    "description": "Erhalten Sie wichtige Warnmeldungen des Bevölkerungsschutzes für Gefahrenlagen wie zum Beispiel Gefahrstoffausbreitung oder Unwetter per Programmierschnittstelle.",
-    "documentationURL": "https://nina.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/nina-api"
-  },  
-  {
-    "name": "ODL-Info API",
-    "office": "Bundesamt für Strahlenschutz",
-    "description": "Daten zur radioaktiven Belastung in Deutschland.",
-    "documentationURL": "https://strahlenschutz.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/strahlenschutz-api"
-  },  
-  {
-    "name": "Reisewarnungen OpenData Schnittstelle",
-    "office": "Auswärtiges Amt",
-    "description": "Zugriff auf Reisewarnungen des Auswärtigen Amtes im Rahmen der OpenData Initiative.",
-    "documentationURL": "https://travelwarning.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/travelwarning-api"
-  },
-  {
-    "name": "Luftqualität",
-    "office": "Umweltbundesamt",
-    "description": "Schnittstellen der unterschiedlichen Visualisierungen der Luftdaten-Seite des Umweltbundesamtes.",
-    "documentationURL": "https://luftqualitaet.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/luftqualitaet-api"
-  },  
-  {
-    "name": "Meeresumweltdatenbank (MUDAB) 1.0.0",
-    "office": "Umweltbundesamt",
-    "description": "Meeres-Monitoringdaten von Küstenbundesländern und Forschungseinrichtungen.",
-    "documentationURL": "https://mudab.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/mudab-api"
-  },
-  {
-    "name": "Lebensmittelwarnungen API",
-    "office": "Bundesamt für Verbraucherschutz und Lebensmittelsicherheit",
-    "description": "Liste aller Lebensmittel und Produktwarnungen.",
-    "documentationURL": "https://lebensmittelwarnung.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/lebensmittelwarnung-api"
->>>>>>> 52387e1bd6c47b2000edc2c73806d18411ec085d
   },
   {
     "name": "Hilfsmittel-API",
@@ -235,7 +126,6 @@
     "githubURL": "https://github.com/bundesAPI/hochwasserzentralen-api"
   },
   {
-<<<<<<< HEAD
     "name": "Interpol Notices API",
     "office": "Interpol",
     "description": "Per Interpol gesuchte oder vermisste Menschen per API abrufen.",
@@ -271,89 +161,3 @@
     "githubURL": "https://github.com/bundesAPI/luftqualitaet-api"
   }
 ]
-=======
-    "name": "Hochwasserzentralen API",
-    "office": "LfU & LUBW",
-    "description": "Länderübergreifendes Hochwasserportal (LHP) ",
-    "documentationURL": "https://bundesapi.github.io/hochwasserzentralen-api/",
-    "githubURL": "https://github.com/bundesAPI/hochwasserzentralen-api"
-  }, 
-  {
-    "name": "Handelsregister",
-    "office": "Landesjustizverwaltung Nordrhein-Westfalen im Auftrag aller Länder der Bundesrepublik Deutschland",
-    "description": "API zum Abruf von allgemeinen Unternehmensinformationen über jedes Unternehmen im Handelsregister.",
-    "documentationURL": null,
-    "githubURL": "https://github.com/bundesAPI/handelsregister"
-  },
-  {
-    "name": "Autobahn App API",
-    "office": "Autobahn GmbH",
-    "description": "Was passiert auf Deutschlands Bundesstraßen? API für aktuelle Verwaltungsdaten zu Baustellen, Staus und Ladestationen. Außerdem Zugang zu Verkehrsüberwachungskameras und vielen weiteren Datensätzen.",
-    "documentationURL": "https://autobahn.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/autobahn-api"
-  },
-  {
-    "name": "DWD App API",
-    "office": "Deutscher Wetterdienst",
-    "description": "Aktuelle Wetterdaten von allen Deutschen Wetterstationen",
-    "documentationURL": "https://dwd.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/dwd-api"
-  },    
-  {
-    "name": "Corona Risikogebiete API",
-    "office": "Robert Koch Institut",
-    "description": "Aktuelle Corona Risikogebietsinformationen als API.",
-    "documentationURL": "https://risikogebiete.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/risikogebiete-api"
-  },
-  {
-    "name": "Interpol Notices API",
-    "office": "Interpol",
-    "description": "Per Interpol gesuchte oder vermisste Menschen per API abrufen.",
-    "documentationURL": "https://interpol.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/interpol-api"
-  },
-  {
-    "name": "Polizei Brandenburg API",
-    "office": "Polizei Brandenburg",
-    "description": "Polizei Brandenburg Nachrichten, Hochwasser-, Verkehrs- und Waldbrandwarnungen.",
-    "documentationURL": "https://polizei.brandenburg.api.bund.dev",
-    "githubURL": "https://github.com/bundesAPI/polizei-brandenburg-api"
-  },
-  {
-    "name": "FIT-Connect",
-    "office": "FITKO",
-    "description": "Die Schnittstelle ermöglicht Ihnen, Anträge und Berichte aus Ihren eigenen Systemen in die unterschiedlichen Systeme der Verwaltung zu übermitteln.",
-    "documentationURL": "https://fit-connect.fitko.de/",
-    "githubURL": "https://git.fitko.de/fit-connect"
-  },    
-  {
-    "name": "VAG API",
-    "office": "VAG",
-    "description": "Web-API für Echtzeitinformationen der VAG",
-    "documentationURL": "https://bundesapi.github.io/vag-api/",
-    "githubURL": "https://github.com/bundesAPI/vag-api"
-  },
-  {
-    "name": "Eco-Visio API",
-    "office": "Eco-Counter",
-    "description": "API zu Eco-Visio von Eco-Counter.",
-    "documentationURL": null,
-    "githubURL": "https://github.com/bundesAPI/eco-visio-api"
-  },
-  {
-    "name": "Abfallnavi API",
-    "office": "regio iT",
-    "description": "Zugriff auf die Termine der Müllabfuhr unterschiedlicher Kommunen.",
-    "documentationURL": "https://bundesapi.github.io/abfallnavi-api/",
-    "githubURL": "https://github.com/bundesAPI/abfallnavi-api"
-  },  
-  {
-    "name": "Feiertage API",
-    "office": "Wikipedia",
-    "description": "Zugriff auf den Feiertage Webservice https://feiertage-api.de/ .",
-    "documentationURL": null,
-    "githubURL": "https://github.com/bundesAPI/feiertage-api"
-  }  
-]
->>>>>>> 52387e1bd6c47b2000edc2c73806d18411ec085d

--- a/overrides.json
+++ b/overrides.json
@@ -1,0 +1,134 @@
+[
+  {
+    "githubURL": "https://github.com/bundesAPI/abfallnavi-api",
+    "office": "regio iT",
+    "documentationURL": "https://bundesapi.github.io/abfallnavi-api/",
+    "description": "Zugriff auf die Termine der Müllabfuhr unterschiedlicher Kommunen."
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/ausbildungssuche-api",
+    "name": "Ausbildungssuche API",
+    "office": "Bundesagentur für Arbeit",
+    "description": "Eine der größten Ausbildungsdatenbanken Deutschlands durchsuchen.",
+    "documentationURL": "https://bundesapi.github.io/ausbildungssuche-api/"
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/autobahn-api",
+    "office": "Autobahn GmbH",
+    "description": "Was passiert auf Deutschlands Bundesstraßen? API für aktuelle Verwaltungsdaten zu Baustellen, Staus und Ladestationen. Außerdem Zugang zu Verkehrsüberwachungskameras und vielen weiteren Datensätzen."
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/berufssprachkurssuche-api",
+    "name": "Berufssprachkurssuche API",
+    "office": "Bundesagentur für Arbeit",
+    "description": "Eine der größten Berufssprachkursdatenbanken Deutschlands durchsuchen.",
+    "documentationURL": "https://bundesapi.github.io/berufssprachkurssuche-api/"
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/bundeshaushalt-api",
+    "office": "Bundesministerium der Finanzen"
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/bundesrat-api",
+    "office": "Bundesrat",
+    "description": "Aktuelle Informationen aus dem deutschen Bundesrat."
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/bundestag-api",
+    "office": "Bundestag",
+    "description": "Aktuelle Informationen aus dem deutschen Bundestag."
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/bundestag-lobbyregister-api",
+    "office": "Deutscher Bundestag",
+    "description": "API des Deutschen Bundestags zum Lobbyregister für die Interessenvertretung gegenüber dem Deutschen Bundestag und der Bundesregierung."
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/coachingangebote-api",
+    "name": "Coachingangebote API",
+    "office": "Bundesagentur für Arbeit",
+    "description": "Eine der größten Datenbanken zu Coaching-/Aktivierungsmaßnahmen Deutschlands durchsuchen.",
+    "documentationURL": "https://bundesapi.github.io/coachingangebote-api/"
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/dashboard-deutschland-api",
+    "office": "Statistisches Bundesamt",
+    "description": "Statistische Daten des DESTATIS Deutschland Deutschland per API abrufen.",
+    "documentationURL": "https://bundesapi.github.io/dashboard-deutschland-api/"
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/destatis-api",
+    "office": "Statistisches Bundesamt",
+    "description": "Statistische Daten des DESTATIS via restful API abrufen."
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/dip-bundestag-api",
+    "office": "Deutscher Bundestag",
+    "description": "Über diese API ist ein lesender Zugriff auf die Entitäten von DIP (Vorgänge und Vorgangspositionen, Aktivitäten, Personen sowie Drucksachen und Plenarprotokolle) möglich.",
+    "documentationURL": "https://dip.bundestag.de/%C3%BCber-dip/hilfe/api"
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/dwd-api",
+    "name": "DWD App API",
+    "office": "Deutscher Wetterdienst",
+    "description": "Aktuelle Wetterdaten von allen Deutschen Wetterstationen"
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/eco-visio-api",
+    "name": "Eco-Visio API",
+    "office": "Eco-Counter"
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/entgeltatlas-api",
+    "name": "Entgeltatlas API",
+    "office": "Bundesagentur für Arbeit",
+    "description": "Eine Datenbank zu Entgelten für Berufstätigkeiten in Deutschland durchsuchen.",
+    "documentationURL": "https://bundesapi.github.io/entgeltatlas-api/"
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/feiertage-api",
+    "office": "Wikipedia",
+    "description": "Zugriff auf den Feiertage Webservice https://feiertage-api.de/."
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/hilfsmittel-api",
+    "name": "Hilfsmittel-API",
+    "office": "Spitzenverband GKV",
+    "description": "API des GKV-Spitzenverbands zu allen Hilfsmitteln, die unter die Leistungspflicht der Kassen fallen."
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/hochwasserzentralen-api",
+    "name": "Hochwasserzentralen API",
+    "office": "LfU & LUBW",
+    "description": "Länderübergreifendes Hochwasserportal (LHP) ",
+    "documentationURL": "https://bundesapi.github.io/hochwasserzentralen-api/"
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/interpol-api",
+    "office": "Interpol",
+    "description": "Per Interpol gesuchte oder vermisste Menschen per API abrufen."
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/jobsuche-api",
+    "name": "Jobsuche API",
+    "office": "Bundesagentur für Arbeit",
+    "description": "Die größte Stellendatenbank Deutschlands durchsuchen, Details zu Stellenanzeigen und Informationen über Arbeitgeber abrufen."
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/ladestationen-api",
+    "name": "Ladesäulenregister",
+    "office": "Bundesnetzagentur",
+    "description": "API des Ladesäulenregisters der Bundesnetzagentur"
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/lebensmittelwarnung-api",
+    "office": "Bundesamt für Verbraucherschutz und Lebensmittelsicherheit",
+    "description": "Liste aller Lebensmittel und Produktwarnungen."
+  },
+  {
+    "githubURL": "https://github.com/bundesAPI/luftqualitaet-api",
+    "name": "Luftqualität",
+    "office": "Umweltbundesamt",
+    "description": "Schnittstellen der unterschiedlichen Visualisierungen der Luftdaten-Seite des Umweltbundesamtes."
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,187 @@
+{
+  "name": "apis",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "apis",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^0.27.2",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "dependencies": {
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "apis",
+  "version": "1.0.0",
+  "description": "This repository hosts the list of documented APIs as JSON (in `index.json`). It can be accessed at https://api.bund.dev/.",
+  "main": "refresh.js",
+  "scripts": {
+    "refresh": "node refresh.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bundesAPI/apis.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/bundesAPI/apis/issues"
+  },
+  "homepage": "https://api.bund.dev",
+  "dependencies": {
+    "axios": "^0.27.2",
+    "js-yaml": "^4.1.0"
+  }
+}

--- a/refresh.js
+++ b/refresh.js
@@ -1,0 +1,59 @@
+const axios = require('axios')
+const yaml = require('js-yaml')
+const fs = require('fs/promises')
+
+const getRepoData = async (repo) => {
+  // fetch openapi spec and CNAME
+  const [{ data: rawRepoData}, { data: cnameData }] = await Promise.all([
+    axios.get(`https://raw.githubusercontent.com/bundesAPI/${repo}/main/openapi.yaml`),
+    axios.get(`https://raw.githubusercontent.com/bundesAPI/${repo}/main/CNAME`)
+  ])
+  const repoData = yaml.load(rawRepoData)
+
+  return {
+    name: repoData.info.title,
+    office: repoData.info['x-office'],
+  }
+}
+
+const main = async () => {
+  // fetch repo list
+  const { data } = await axios.get('https://api.github.com/users/BundesAPI/repos')
+
+  // only check repos that end in "-api"
+  const repos = data.filter((repo) => repo.name.endsWith('-api'))
+
+  const result = await Promise.all(repos.map(async (repo) => {
+    const { data: rawRepoData } = await axios.get(`https://raw.githubusercontent.com/bundesAPI/${repo.name}/main/openapi.yaml`)
+    const repoData = yaml.load(rawRepoData)
+
+    return {
+      name: repoData.info.title,
+      office: repoData.info['x-office'],
+      description: repo.description,
+      documentationURL: repo.homepage,
+      githubURL: repo.html_url
+    }
+  }))
+
+  console.log(result)
+
+  const overridesRaw = await fs.readFile('./overrides.json', { encoding: 'utf-8' })
+  const overrides = await JSON.parse(overridesRaw)
+
+  // upsert list
+  const newList = result.map((repo) => {
+    const overrideIndex = overrides.findIndex((e) => e.githubURL === repo.githubURL)
+    if (overrideIndex === -1) return repo
+
+    return {
+      ...repo,
+      ...overrides[overrideIndex]
+    }
+  })
+
+  // write list back
+  await fs.writeFile('./index.json', JSON.stringify(newList, null, 2), { encoding: 'utf-8' })
+}
+
+main()

--- a/refresh.js
+++ b/refresh.js
@@ -2,20 +2,6 @@ const axios = require('axios')
 const yaml = require('js-yaml')
 const fs = require('fs/promises')
 
-const getRepoData = async (repo) => {
-  // fetch openapi spec and CNAME
-  const [{ data: rawRepoData}, { data: cnameData }] = await Promise.all([
-    axios.get(`https://raw.githubusercontent.com/bundesAPI/${repo}/main/openapi.yaml`),
-    axios.get(`https://raw.githubusercontent.com/bundesAPI/${repo}/main/CNAME`)
-  ])
-  const repoData = yaml.load(rawRepoData)
-
-  return {
-    name: repoData.info.title,
-    office: repoData.info['x-office'],
-  }
-}
-
 const main = async () => {
   // fetch repo list
   const { data } = await axios.get('https://api.github.com/users/BundesAPI/repos')
@@ -35,8 +21,6 @@ const main = async () => {
       githubURL: repo.html_url
     }
   }))
-
-  console.log(result)
 
   const overridesRaw = await fs.readFile('./overrides.json', { encoding: 'utf-8' })
   const overrides = await JSON.parse(overridesRaw)


### PR DESCRIPTION
See discussion in https://github.com/bundesAPI/sofortmassnahmen/issues/68.

This PR introduces a workflow to automatically update the API list in `index.json`.

* runs every day at 4 in the morning (can also be run manually)
* respects overrides set in `overrides.json`
* creates a PR if something has changed (see [example PR](https://github.com/jens-ox/bundesapi-apis/pull/1) in the fork)

Content is generated from the following sources:

* `name`: `info.title` field in `openapi.yaml`
* `office` `info.x-office` field in `openapi.yaml` (currently not set in any repo)
* `description`: repo description
* `documentationURL`: repo project URL

A follow-up would be to properly set all project URLs etc. in the different repos (which also makes sense from a general documentation point of view).