### PR TITLE
Added documentation (openapi) for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Bundesstelle Open Data API
+
+This repository contains a list of APIs documented by [BundDEV](https://github.com/bundesAPI).
+
+This list is provided at the following link: [api.bund.dev](https://api.bund.dev).
+
+
+### Documentation
+The documentation for this API can be found at [here](https://api.bund.dev/docs/).
+
+---
+
+### Refresh
+
+Every 24 hours, a GitHub action will check for changes and new APIs. If changes are detected, there will be a pull request for the changes to the `index.json`.
+
+### Overrides
+Since not every information is provided by the OpenAPI or the GitHub repository of an API the `overrides.json` contains additional information which is added.
+
+
+### Actions
+
+[![Refresh API list](https://github.com/bundesAPI/apis/actions/workflows/refresh.yml/badge.svg)](https://github.com/bundesAPI/apis/actions/workflows/refresh.yml)

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.51.1/swagger-ui.min.css">
+    <title>BundDEV APIs - OpenAPI Documentation</title>
+
+<body>
+    <div><small><a href="index.html">[DE]</a><a id="en" href="#">/[EN]</a></small></div>
+
+    <div id="openapi">
+
+    <script src="//cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.51.1/swagger-ui-bundle.min.js"></script>
+    <script>
+        var xhr = new XMLHttpRequest();
+        xhr.open('HEAD', "openapi_en.yaml", true);
+        xhr.onreadystatechange = function(){
+          if (xhr.readyState === 4){
+            if (xhr.status === 404) {
+              document.getElementById('en').remove();
+            }
+          }
+        };
+        xhr.send();
+        if (document.getElementById('en') !== null)
+ 	document.getElementById('en').onclick = function() {
+            const ui = SwaggerUIBundle({
+                url: "openapi_en.yaml",
+                dom_id: "#openapi"
+            })
+	};
+        window.onload = function () {
+            const ui = SwaggerUIBundle({
+                url: "openapi.yaml",
+                dom_id: "#openapi"
+            })
+        }
+    </script>
+</body>
+</html>

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,68 @@
+openapi: "3.0.0"
+info:
+  version: "1.0.0"
+  title: "API Liste"
+  description: "Sammlung der APIs der Bundesstelle für Open Data"
+  contact:
+    name: "Bundesstelle für Open Data"
+    url: "https://bund.dev/"
+    email: "kontakt@bund.dev"
+
+servers:
+  - url: "https://api.bund.dev"
+
+tags:
+  - name: api
+paths:
+  /:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+                schema:
+                  $ref: "#/components/schemas/responses"
+
+      summary: "API"
+      description: "API Liste"
+      tags:
+        - api
+
+
+components:
+  schemas:
+    responses:
+        type: array
+        items:
+            type: object
+            properties:
+              name:
+                type: string
+                example: Abfallnavi API
+                description: Name der API
+              office:
+                type: string
+                nullable: true
+                example: regio iT
+                description: Zugehörige verantwortliche Behörde oder Unternehmen/Person
+              description:
+                type: string
+                nullable: true
+                example: Zugriff auf die Termine der Müllabfuhr unterschiedlicher Kommunen.
+                description: Kurzbeschreibung
+              documentationURL:
+                type: string
+                nullable: true
+                example: https://bundesapi.github.io/abfallnavi-api/
+                description: Öffentliche Dokumentations-URL
+              githubURL:
+                type: string
+                nullable: true
+                example: https://github.com/bundesAPI/abfallnavi-api
+                description: GitHub-URL
+              rawOpenAPI:
+                type: string
+                nullable: true
+                example: https://raw.githubusercontent.com/bundesAPI/abfallnavi-api/main/openapi.yaml
+                description: raw OpenAPI-Spezifikation

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -23,7 +23,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/responses"
+                $ref: "#/components/schemas/response"
 
       summary: "API"
       description: "API Liste"
@@ -32,7 +32,7 @@ paths:
 
 components:
   schemas:
-    responses:
+    response:
       type: array
       items:
         type: object
@@ -49,7 +49,7 @@ components:
           description:
             type: string
             nullable: true
-            example: Zugriff auf die Termine der Müllabfuhr unterschiedlicher Kommunen.
+            example: Zugriff auf die Termine der Müllabfuhr unterschiedlicher Kommunen
             description: Kurzbeschreibung
           documentationURL:
             type: string

--- a/docs/openapi_en.yaml
+++ b/docs/openapi_en.yaml
@@ -23,7 +23,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/responses"
+                $ref: "#/components/schemas/response"
 
       summary: "API"
       description: "API List"
@@ -32,7 +32,7 @@ paths:
 
 components:
   schemas:
-    responses:
+    response:
       type: array
       items:
         type: object
@@ -49,7 +49,7 @@ components:
           description:
             type: string
             nullable: true
-            example: Zugriff auf die Termine der Müllabfuhr unterschiedlicher Kommunen.
+            example: Zugriff auf die Termine der Müllabfuhr unterschiedlicher Kommunen
             description: Short description
           documentationURL:
             type: string

--- a/docs/openapi_en.yaml
+++ b/docs/openapi_en.yaml
@@ -1,8 +1,8 @@
 openapi: "3.0.0"
 info:
   version: "1.0.0"
-  title: "API Liste"
-  description: "Sammlung der APIs der Bundesstelle für Open Data"
+  title: "API List"
+  description: "Collection of APIs of the Bundesstelle für Open Data"
   contact:
     name: "Bundesstelle für Open Data"
     url: "https://bund.dev/"
@@ -26,7 +26,7 @@ paths:
                 $ref: "#/components/schemas/responses"
 
       summary: "API"
-      description: "API Liste"
+      description: "API List"
       tags:
         - api
 
@@ -40,22 +40,22 @@ components:
           name:
             type: string
             example: Abfallnavi API
-            description: Name der API
+            description: Name of the API
           office:
             type: string
             nullable: true
             example: regio iT
-            description: Zugehörige verantwortliche Behörde oder Unternehmen/Person
+            description: Related responsible authority or company/person
           description:
             type: string
             nullable: true
             example: Zugriff auf die Termine der Müllabfuhr unterschiedlicher Kommunen.
-            description: Kurzbeschreibung
+            description: Short description
           documentationURL:
             type: string
             nullable: true
             example: https://bundesapi.github.io/abfallnavi-api/
-            description: Öffentliche Dokumentations-URL
+            description: Public documentation URL
           githubURL:
             type: string
             nullable: true
@@ -65,4 +65,4 @@ components:
             type: string
             nullable: true
             example: https://raw.githubusercontent.com/bundesAPI/abfallnavi-api/main/openapi.yaml
-            description: raw OpenAPI-Spezifikation
+            description: raw OpenAPI specification


### PR DESCRIPTION
Since we have all these good OpenAPI specifications for other APIs. I think we should have one for this API as well. 

I added the `docs` folder so there are no changes in the URL. 

Example documentation: https://t-huyeng.github.io/bunddev-apis/docs/

TODO
- [x] add english openapi
- [x] update Readme