### PR TITLE
Update overrides.json

### DIFF
--- a/overrides.json
+++ b/overrides.json
@@ -294,14 +294,6 @@
     "githubURL": "https://github.com/bundesAPI/hilfsmittel-api"
   },
   {
-    "name": "Wasserstraßen- und Schifffahrtsverwaltung: Pegel-Online API",
-    "office": "WSV",
-    "description": "Pegelstände der Messstellen des bundesweiten Messstellennetzes der Wasserstraßen- und Schifffahrtsverwaltung des Bundes.",
-    "documentationURL": null,
-    "githubURL": "https://github.com/bundesAPI/pegel-online-api"
-  },
-
-  {
     "name": "Marktdatenstammregister API",
     "office": "Bundesnetzagentur",
     "description": "Das Marktstammdatenregister ist das Register für den deutschen Strom- und Gasmarkt, abgekürzt MaStR",


### PR DESCRIPTION
Removed pegel api from overrides, since x-office got merged into the openapi.yaml.